### PR TITLE
XRT-2636 Fix naming inconsistencies in tests and add a timeout condition on the host connect

### DIFF
--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/AwareBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/AwareBrokerTest.java
@@ -130,7 +130,7 @@ public class AwareBrokerTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Broker Sparkplug Aware";
+		return "Broker SparkplugAware";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/CompliantBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/CompliantBrokerTest.java
@@ -141,7 +141,7 @@ public class CompliantBrokerTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Broker Sparkplug Compliant";
+		return "Broker SparkplugCompliant";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/MultipleBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/MultipleBrokerTest.java
@@ -274,7 +274,7 @@ public class MultipleBrokerTest extends TCKTest {
 
 	@Override
 	public String getName() {
-		return "Edge Multiple Broker";
+		return "Edge MultipleBroker";
 	}
 
 	@Override

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/PrimaryHostTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/PrimaryHostTest.java
@@ -323,7 +323,7 @@ public class PrimaryHostTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Edge Primary Host";
+		return "Edge PrimaryHost";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendComplexDataTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendComplexDataTest.java
@@ -219,7 +219,7 @@ public class SendComplexDataTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Edge Send Complex Data";
+		return "Edge SendComplexData";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/EdgeSessionTerminationTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/EdgeSessionTerminationTest.java
@@ -155,7 +155,7 @@ public class EdgeSessionTerminationTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Sparkplug Host Edge Node Session Termination Test";
+		return "Host SessionTermination";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MessageOrderingTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MessageOrderingTest.java
@@ -165,7 +165,7 @@ public class MessageOrderingTest extends TCKTest {
 
 	@Override
 	public String getName() {
-		return "Host Message Ordering";
+		return "Host MessageOrdering";
 	}
 
 	@Override

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MultipleBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MultipleBrokerTest.java
@@ -196,7 +196,7 @@ public class MultipleBrokerTest extends TCKTest {
 
 	@Override
 	public String getName() {
-		return "Host Multiple Broker";
+		return "Host MultipleBroker";
 	}
 
 	@Override

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/utility/HostApplication.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/utility/HostApplication.java
@@ -132,6 +132,7 @@ public class HostApplication {
 
 		MqttConnectOptions connectOptions = new MqttConnectOptions();
 		connectOptions.setWill(stateTopic, deathPayload, 1, true);
+		host.setTimeToWait(5000);
 		host.connect(connectOptions);
 		logger.info("Host " + host_application_id + " successfully created");
 	}


### PR DESCRIPTION
This PR standardises tests names to allow for processing of results as well as adding a timeout condition on the host application connect so that the TCK does not indefinitely hang when this connection fails